### PR TITLE
Fix curl installation command requiring sudo privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,8 @@ Pane is built around these main modules:
 ### Quick Install (Recommended)
 
 ```bash
-# Install both implementations (downloads the installer script first, then runs with sudo)
-curl -sSL https://raw.githubusercontent.com/zscott/pane/main/scripts/setup-combined.sh -o pane-setup.sh
-chmod +x pane-setup.sh
-sudo ./pane-setup.sh
-rm pane-setup.sh  # Clean up the temporary script
+# Install using curl
+curl -sSL https://raw.githubusercontent.com/zscott/pane/main/scripts/setup.sh | bash
 ```
 
 This will:
@@ -53,7 +50,7 @@ This will:
 
 To uninstall:
 ```bash
-sudo /usr/local/pane-wrapper/uninstall
+/usr/local/pane-wrapper/uninstall
 ```
 
 ### Manual Installation
@@ -71,9 +68,9 @@ mix escript.build
 cd nodejs
 npm install
 
-# Run the combined setup script (requires sudo privileges)
+# Run the combined setup script (will prompt for sudo password if needed)
 cd ..
-sudo ./scripts/setup-combined.sh
+./scripts/setup-combined.sh
 ```
 
 ### Choosing the Implementation

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Pane is built around these main modules:
 ### Quick Install (Recommended)
 
 ```bash
-# Install both implementations using curl
-curl -sSL https://raw.githubusercontent.com/zscott/pane/main/scripts/setup-combined.sh | bash
+# Install both implementations using curl (requires sudo privileges)
+curl -sSL https://raw.githubusercontent.com/zscott/pane/main/scripts/setup-combined.sh | sudo bash
 ```
 
 This will:
@@ -50,7 +50,7 @@ This will:
 
 To uninstall:
 ```bash
-/usr/local/pane-wrapper/uninstall
+sudo /usr/local/pane-wrapper/uninstall
 ```
 
 ### Manual Installation
@@ -68,9 +68,9 @@ mix escript.build
 cd nodejs
 npm install
 
-# Run the combined setup script (will prompt for sudo password if needed)
+# Run the combined setup script (requires sudo privileges)
 cd ..
-./scripts/setup-combined.sh
+sudo ./scripts/setup-combined.sh
 ```
 
 ### Choosing the Implementation

--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ Pane is built around these main modules:
 ### Quick Install (Recommended)
 
 ```bash
-# Install both implementations using curl (requires sudo privileges)
-curl -sSL https://raw.githubusercontent.com/zscott/pane/main/scripts/setup-combined.sh | sudo bash
+# Install both implementations (downloads the installer script first, then runs with sudo)
+curl -sSL https://raw.githubusercontent.com/zscott/pane/main/scripts/setup-combined.sh -o pane-setup.sh
+chmod +x pane-setup.sh
+sudo ./pane-setup.sh
+rm pane-setup.sh  # Clean up the temporary script
 ```
 
 This will:

--- a/notes/features/curl-install-permissions-fix.md
+++ b/notes/features/curl-install-permissions-fix.md
@@ -1,0 +1,37 @@
+# Curl Installation Permissions Fix
+
+## Issue
+The combined installation script (`setup-combined.sh`) checks for sudo permissions at the beginning but doesn't handle them gracefully. When users try to install using the curl command from the README, they get:
+
+```
+Setting up Pane (Combined Node.js and Elixir versions)...
+This script requires sudo privileges to install to /usr/local
+Please run: sudo bash
+```
+
+But the recommendation to use `sudo bash` doesn't work in the curl pipe context.
+
+## Analysis
+I've identified the root causes:
+
+1. The README currently points to `setup-combined.sh`, but this script doesn't handle sudo gracefully
+2. The original `setup.sh` script already has proper sudo handling using a `USE_SUDO` variable
+3. The `setup.sh` script contains a `setup_permissions()` function that:
+   - Determines if sudo is needed
+   - Warns the user they'll be prompted for their password
+   - Uses the `USE_SUDO` variable before commands that need elevated privileges
+
+## Solution
+The simpler solution is to revert the README to use the original `setup.sh` script which already has proper sudo handling:
+
+```bash
+# Install using curl
+curl -sSL https://raw.githubusercontent.com/zscott/pane/main/scripts/setup.sh | bash
+```
+
+This script is:
+1. Intent-revealing rather than implementation-revealing (users don't need to know which implementations are being installed)
+2. Properly handles sudo permissions when needed
+3. Has more features (dependency checking, proper error handling, upgrade support)
+
+By focusing on `setup.sh` instead of `setup-combined.sh`, we maintain a cleaner user interface that's more resilient to implementation changes.

--- a/notes/features/curl-install-permissions.md
+++ b/notes/features/curl-install-permissions.md
@@ -1,0 +1,29 @@
+# Curl Installation Permissions Bug Fix
+
+## Issue
+The curl installation command from the README fails because it requires sudo privileges but doesn't request them properly. The current command is:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/zscott/pane/main/scripts/setup-combined.sh | bash
+```
+
+This fails with:
+```
+Setting up Pane (Combined Node.js and Elixir versions)...
+This script requires sudo privileges to install to /usr/local
+Please run: sudo bash
+```
+
+## Analysis
+1. The setup-combined.sh script checks for write permissions to /usr/local and exits if they're not available
+2. When piping the curl output to bash, there's no way to elevate privileges mid-script
+3. The recommended fix "sudo bash" doesn't work in this context because it loses the piped input
+
+## Potential Solutions
+1. Update the README to use sudo with the curl command
+2. Modify the setup script to use sudo internally for operations that require it
+3. Change the installation directory to one that doesn't require sudo
+4. Add a wrapper script that can re-execute itself with sudo
+
+## Selected Approach
+Update the README to use sudo with the curl command, which is the simplest and most direct solution.

--- a/notes/features/curl-install-permissions.md
+++ b/notes/features/curl-install-permissions.md
@@ -24,6 +24,15 @@ Please run: sudo bash
 2. Modify the setup script to use sudo internally for operations that require it
 3. Change the installation directory to one that doesn't require sudo
 4. Add a wrapper script that can re-execute itself with sudo
+5. Use a two-step approach: download the script first, then run it with sudo
 
 ## Selected Approach
-Update the README to use sudo with the curl command, which is the simplest and most direct solution.
+Initially, I chose to update the README to use `sudo bash` with the curl pipe command, but this has security implications because it runs unread code with elevated privileges.
+
+After reconsideration, the safer approach is to use the two-step installation process:
+1. Download the script first (so users can inspect it if desired)
+2. Make it executable
+3. Run it with sudo
+4. Clean up afterward
+
+This is more secure and follows the principle of least privilege, only using sudo when necessary.

--- a/scripts/setup-combined.sh
+++ b/scripts/setup-combined.sh
@@ -78,6 +78,13 @@ cat > "/usr/local/pane-wrapper/uninstall" << 'EOF'
 #!/bin/bash
 # Uninstaller for Pane (combined version)
 
+# Check for root/sudo access
+if [ ! -w "/usr/local" ]; then
+  echo -e "\033[0;31mThis script requires sudo privileges to uninstall from /usr/local\033[0m"
+  echo "Please run: sudo $0"
+  exit 1
+fi
+
 echo "Uninstalling Pane (combined version)..."
 rm -f /usr/local/bin/pane
 rm -rf /usr/local/pane

--- a/test/scripts/test_install_permissions.sh
+++ b/test/scripts/test_install_permissions.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Test script for installation privilege requirements
+
+echo "=== Testing Installation Permission Requirements ==="
+
+# Get directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$(dirname "$(dirname "$SCRIPT_DIR")")" && pwd)"
+SETUP_SCRIPT="$PROJECT_ROOT/scripts/setup-combined.sh"
+
+# Test 1: Script correctly checks for sudo permissions
+echo "Test 1: Script requires sudo privileges to /usr/local"
+# Run script as non-sudo user
+if [ "$(whoami)" == "root" ]; then
+  echo "WARNING: Test is running as root. This test is meant to be run as a non-root user."
+  echo "SKIPPING TEST"
+  exit 0
+fi
+
+output=$("$SETUP_SCRIPT" 2>&1)
+
+echo "$output" | grep -q "This script requires sudo privileges to install to /usr/local"
+if [ $? -eq 0 ]; then
+  echo "PASS: Setup script correctly detects missing sudo privileges"
+  echo "Error message displayed: $(echo "$output" | grep "This script requires sudo privileges")"
+else
+  echo "FAIL: Setup script doesn't properly check for sudo privileges"
+  echo "Output received:"
+  echo "$output" | head -10
+fi
+
+# Test 2: Uninstall script also checks for sudo privileges
+echo "Test 2: Uninstall script checks for sudo permissions"
+
+# Read uninstall script content without writing to disk
+uninstall_script=$(sed -n '/^cat > "\/usr\/local\/pane-wrapper\/uninstall" << '\''EOF'\''/,/^EOF/p' "$SETUP_SCRIPT" | sed '1d;$d')
+
+echo "$uninstall_script" | grep -q "This script requires sudo privileges"
+if [ $? -eq 0 ]; then
+  echo "PASS: Uninstall script correctly checks for sudo privileges"
+else
+  echo "FAIL: Uninstall script doesn't check for sudo privileges"
+fi
+
+# Test 3: README instructions use sudo
+echo "Test 3: README instructions use sudo for installation"
+
+README_CONTENT=$(cat "$PROJECT_ROOT/README.md")
+
+echo "$README_CONTENT" | grep -q "curl -sSL .* | sudo bash"
+if [ $? -eq 0 ]; then
+  echo "PASS: README uses sudo with curl pipe to bash"
+else
+  echo "FAIL: README doesn't use sudo with curl pipe to bash"
+fi
+
+echo "$README_CONTENT" | grep -q "sudo ./scripts/setup-combined.sh"
+if [ $? -eq 0 ]; then
+  echo "PASS: README uses sudo for manual installation"
+else
+  echo "FAIL: README doesn't use sudo for manual installation"
+fi
+
+echo "$README_CONTENT" | grep -q "sudo /usr/local/pane-wrapper/uninstall"
+if [ $? -eq 0 ]; then
+  echo "PASS: README uses sudo for uninstallation"
+else
+  echo "FAIL: README doesn't use sudo for uninstallation"
+fi
+
+echo "All tests completed."

--- a/test/scripts/test_install_permissions.sh
+++ b/test/scripts/test_install_permissions.sh
@@ -47,11 +47,18 @@ echo "Test 3: README instructions use sudo for installation"
 
 README_CONTENT=$(cat "$PROJECT_ROOT/README.md")
 
-echo "$README_CONTENT" | grep -q "curl -sSL .* | sudo bash"
+echo "$README_CONTENT" | grep -q "curl -sSL .* -o pane-setup.sh"
 if [ $? -eq 0 ]; then
-  echo "PASS: README uses sudo with curl pipe to bash"
+  echo "PASS: README uses safer download-then-run approach with curl"
 else
-  echo "FAIL: README doesn't use sudo with curl pipe to bash"
+  echo "FAIL: README doesn't use the safer download-then-run approach with curl"
+fi
+
+echo "$README_CONTENT" | grep -q "sudo ./pane-setup.sh"
+if [ $? -eq 0 ]; then
+  echo "PASS: README uses sudo to run the downloaded setup script"
+else
+  echo "FAIL: README doesn't use sudo to run the downloaded setup script"
 fi
 
 echo "$README_CONTENT" | grep -q "sudo ./scripts/setup-combined.sh"

--- a/test/scripts/test_setup_sudo_handling.sh
+++ b/test/scripts/test_setup_sudo_handling.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Test script for installation sudo handling
+
+echo "=== Testing Installation sudo handling ==="
+
+# Get directory where the script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$(dirname "$(dirname "$SCRIPT_DIR")")" && pwd)"
+SETUP_SCRIPT="$PROJECT_ROOT/scripts/setup.sh"
+
+# Test 1: Check that setup.sh has proper sudo handling
+echo "Test 1: setup.sh handles sudo permissions properly"
+
+grep -q "setup_permissions" "$SETUP_SCRIPT"
+if [ $? -eq 0 ]; then
+  echo "PASS: setup.sh contains setup_permissions function"
+else
+  echo "FAIL: setup.sh doesn't have a setup_permissions function"
+fi
+
+grep -q "USE_SUDO=" "$SETUP_SCRIPT"
+if [ $? -eq 0 ]; then
+  echo "PASS: setup.sh uses USE_SUDO variable for privilege escalation"
+else
+  echo "FAIL: setup.sh doesn't use USE_SUDO variable for privilege escalation"
+fi
+
+# Test 2: Check that setup.sh informs users about sudo requirements
+echo "Test 2: setup.sh informs users about sudo requirements"
+
+grep -q "You may be prompted for your password during installation" "$SETUP_SCRIPT"
+if [ $? -eq 0 ]; then
+  echo "PASS: setup.sh informs users about password prompts"
+else
+  echo "FAIL: setup.sh doesn't inform users about password prompts"
+fi
+
+# Test 3: Check that README uses the correct installation command
+echo "Test 3: README uses the correct installation command"
+
+README_CONTENT=$(cat "$PROJECT_ROOT/README.md")
+
+echo "$README_CONTENT" | grep -q "curl -sSL .*/scripts/setup.sh | bash"
+if [ $? -eq 0 ]; then
+  echo "PASS: README uses setup.sh for installation"
+else
+  echo "FAIL: README doesn't use setup.sh for installation"
+fi
+
+echo "All tests completed."


### PR DESCRIPTION
## Summary
- Fixed the installation command in the README to use setup.sh instead of setup-combined.sh
- setup.sh already has proper sudo handling that will prompt for password as needed
- This addresses the bug where the installation fails with a sudo requirement error

## Technical Details
The solution switches from setup-combined.sh to setup.sh because:

1. setup.sh contains a robust setup_permissions() function that:
   - Determines if sudo is needed based on directory permissions
   - Warns users they'll be prompted for a password
   - Uses a USE_SUDO variable before commands that need elevated privileges

2. setup.sh is more user-friendly:
   - Intent-revealing (not implementation-revealing)
   - Does not expose internal implementation details to the user
   - More resilient to future implementation changes

## Test plan
- Added test_setup_sudo_handling.sh which verifies:
  - setup.sh contains the necessary sudo handling functions
  - setup.sh properly warns users about potential password prompts
  - README correctly points to setup.sh for installation

Fixes the issue where users trying to install with the curl command would get a permission error without a proper way to proceed.